### PR TITLE
Add: add multiple files argument ; Add , PIN: add arguments from IPFS docs

### DIFF
--- a/ipyfs/RPCs/add.py
+++ b/ipyfs/RPCs/add.py
@@ -5,7 +5,7 @@ class Add(IPFS):
 
     def __call__(
         self,
-        file,
+        file = None,
         quiet: bool = None,
         quieter: bool = None,
         silent: bool = None,
@@ -15,18 +15,21 @@ class Add(IPFS):
         wrap_with_directory: bool = None,
         chunker: str = None,
         pin: bool = None,
+        pin_name: str = None,
         raw_leaves: bool = None,
         nocopy: bool = None,
         fscache: bool = None,
         cid_version: int = None,
         hash: str = None,
         inline: bool = None,
-        inline_limit: int = None
+        inline_limit: int = None,
+        to_files: str = None,
+        files: dict = None,
     ) -> dict:
         """
         Add a file or directory to IPFS.
 
-        :param file: File to add. Required: yes.
+        :param file: File to add. Required: yes, unless files is passed.
         :param quiet: Write minimal output. Required: no.
         :param quieter: Write only final hash. Required: no.
         :param silent: Write no output. Required: no.
@@ -36,6 +39,7 @@ class Add(IPFS):
         :param wrap_with_directory: Wrap files with a directory object. Required: no.
         :param chunker: Chunking algorithm, size-[bytes], rabin-[min]-[avg]-[max] or buzhash. Default: size-262144. Required: no.
         :param pin: Pin this object when adding. Default: true. Required: no.
+        :param pin_name: Name to use for the pin.Required: no.
         :param raw_leaves: Use raw blocks for leaf nodes. Required: no.
         :param nocopy: Add the file using filestore. Implies raw-leaves. (experimental). Required: no.
         :param fscache: Check the filestore for pre-existing blocks. (experimental). Required: no.
@@ -43,17 +47,24 @@ class Add(IPFS):
         :param hash: Hash function to use. Implies CIDv1 if not sha2-256. (experimental). Default: sha2-256. Required: no.
         :param inline: Inline small blocks into CIDs. (experimental). Required: no.
         :param inline_limit: Maximum block size to inline. (experimental). Default: 32. Required: no.
+        :param to_files: Add reference to Files API (MFS) at the provided path. Required: no.
+        :param files: add multiple files - see requests.request => files parameter 
         :return response: Response from IPFS.
         """
+        if file is None and files is None:
+            raise(TypeError(" missing one of required : first positional argument: 'file' or keyword argument: 'files'"))
         replace = {
             "only_hash": "only-hash",
             "wrap_with_directory": "wrap-with-directory",
             "raw_leaves": "raw-leaves",
             "cid_version": "cid-version",
-            "inline_limit": "inline-limit"
+            "inline_limit": "inline-limit",
+            "to_files": "to-files",
+            "pin_name": "pin-name"
         }
         return self._send(
             params=locals(),
             replace=replace,
-            file=file
+            file=file,
+            files=files
         )

--- a/ipyfs/RPCs/bootstrap.py
+++ b/ipyfs/RPCs/bootstrap.py
@@ -3,10 +3,10 @@ from ipyfs.ipfs import IPFS
 
 class BootStrap(IPFS):
 
-    def __init__(self):
-        super(BootStrap, self).__init__()
-        self.add = self.Add()
-        self.rm = self.Rm()
+    def __init__(self,**kwargs):
+        super().__init__(**kwargs)
+        self.add = self.Add(**kwargs)
+        self.rm = self.Rm(**kwargs)
 
     def __call__(self) -> dict:
         """
@@ -18,8 +18,8 @@ class BootStrap(IPFS):
 
     class Add(IPFS):
 
-        def __init__(self):
-            super(BootStrap.Add, self).__init__()
+        def __init__(self,**kwargs):
+            super().__init__(**kwargs)
 
         def __call__(
             self,
@@ -49,8 +49,8 @@ class BootStrap(IPFS):
 
     class Rm(IPFS):
 
-        def __init__(self):
-            super(BootStrap.Rm, self).__init__()
+        def __init__(self,**kwargs):
+            super().__init__(**kwargs)
 
         def __call__(
             self,

--- a/ipyfs/RPCs/commands.py
+++ b/ipyfs/RPCs/commands.py
@@ -3,9 +3,9 @@ from ipyfs.ipfs import IPFS
 
 class Commands(IPFS):
 
-    def __init__(self):
-        super(Commands, self).__init__()
-        self.completion = self.Completion()
+    def __init__(self,**kwargs):
+        super().__init__(**kwargs)
+        self.completion = self.Completion(**kwargs)
 
     def __call__(
         self,
@@ -21,8 +21,8 @@ class Commands(IPFS):
 
     class Completion(IPFS):
 
-        def __init__(self):
-            super(Commands.Completion, self).__init__()
+        def __init__(self,**kwargs):
+            super().__init__(**kwargs)
 
         def bash(self) -> dict:
             """

--- a/ipyfs/RPCs/config.py
+++ b/ipyfs/RPCs/config.py
@@ -3,9 +3,9 @@ from ipyfs.ipfs import IPFS
 
 class Config(IPFS):
 
-    def __init__(self):
-        super(Config, self).__init__()
-        self.profile = self.Profile()
+    def __init__(self,**kwargs):
+        super().__init__(**kwargs)
+        self.profile = self.Profile(**kwargs)
 
     def __call__(
         self,
@@ -34,8 +34,8 @@ class Config(IPFS):
 
     class Profile(IPFS):
 
-        def __init__(self):
-            super(Config.Profile, self).__init__()
+        def __init__(self,**kwargs):
+            super().__init__(**kwargs)
 
         def apply(
             self,

--- a/ipyfs/RPCs/diag.py
+++ b/ipyfs/RPCs/diag.py
@@ -3,14 +3,14 @@ from ipyfs.ipfs import IPFS
 
 class Diag(IPFS):
 
-    def __init__(self):
-        super(Diag, self).__init__()
-        self.cmds = self.Cmds()
+    def __init__(self,**kwargs):
+        super().__init__(**kwargs)
+        self.cmds = self.Cmds(**kwargs)
 
     class Cmds(IPFS):
 
-        def __init__(self):
-            super(Diag.Cmds, self).__init__()
+        def __init__(self,**kwargs):
+            super().__init__(**kwargs)
 
         def __call__(
             self,

--- a/ipyfs/RPCs/pin.py
+++ b/ipyfs/RPCs/pin.py
@@ -3,15 +3,16 @@ from ipyfs.ipfs import IPFS
 
 class Pin(IPFS):
 
-    def __init__(self):
-        super(Pin, self).__init__()
-        self.remote = self.Remote()
+    def __init__(self,**kwargs):
+        super().__init__(**kwargs)
+        self.remote = self.Remote(**kwargs)
 
     def add(
         self,
         path: str,
         recursive: bool = None,
-        progress: bool = None
+        progress: bool = None,
+        name: str = None
     ) -> dict:
         """
         Pin objects to local storage.
@@ -19,6 +20,7 @@ class Pin(IPFS):
         :param path: Path to object(s) to be pinned. Required: yes.
         :param recursive: Recursively pin the object linked to by the specified object(s). Default: true. Required: no.
         :param progress: Show progress. Required: no.
+        :param name: An optional name for created pin(s). Required: no.
         :return response: Response from IPFS.
         """
         replace = {"path": "arg"}
@@ -32,7 +34,9 @@ class Pin(IPFS):
         path: str = None,
         type: str = None,
         quiet: bool = None,
-        stream: bool = None
+        stream: bool = None,
+        name: str = None,
+        names: bool = None
     ) -> dict:
         """
         List objects pinned to local storage.
@@ -41,6 +45,8 @@ class Pin(IPFS):
         :param type: The type of pinned keys to list. Can be "direct", "indirect", "recursive", or "all". Default: all. Required: no.
         :param quiet: Write just hashes of objects. Required: no.
         :param stream: Enable streaming of pins as they are discovered. Required: no.
+        :param name: Limit returned pins to ones with names that contain the value provided (case-sensitive, partial match). Implies --names=true. Required: no.
+        :param names: Include pin names in the output (slower, disabled by default). Required: no.
         :return response: Response from IPFS.
         """
         replace = {"path": "arg"}
@@ -106,9 +112,9 @@ class Pin(IPFS):
 
     class Remote(IPFS):
 
-        def __init__(self):
-            super(Pin.Remote).__init__()
-            self.service = self.Service()
+        def __init__(self,**kwargs):
+            super().__init__(**kwargs)
+            self.service = self.Service(**kwargs)
 
         def add(
             self,
@@ -172,8 +178,8 @@ class Pin(IPFS):
 
         class Service(IPFS):
 
-            def __init__(self):
-                super(Pin.Remote.Service).__init__()
+            def __init__(self,**kwargs):
+                super().__init__(**kwargs)
 
             def add(
                 self,

--- a/ipyfs/RPCs/swarm.py
+++ b/ipyfs/RPCs/swarm.py
@@ -3,11 +3,11 @@ from ipyfs.ipfs import IPFS
 
 class Swarm(IPFS):
 
-    def __init__(self):
-        super(Swarm, self).__init__()
-        self.addrs = self.Addrs()
-        self.filters = self.Filters()
-        self.peering = self.Peering()
+    def __init__(self,**kwargs):
+        super().__init__(**kwargs)
+        self.addrs = self.Addrs(**kwargs)
+        self.filters = self.Filters(**kwargs)
+        self.peering = self.Peering(**kwargs)
 
     def connect(
         self,
@@ -61,8 +61,8 @@ class Swarm(IPFS):
 
     class Addrs(IPFS):
 
-        def __init__(self):
-            super(Swarm.Addrs, self).__init__()
+        def __init__(self,**kwargs):
+            super().__init__(**kwargs)
 
         def __call__(self) -> dict:
             """
@@ -93,8 +93,8 @@ class Swarm(IPFS):
 
     class Filters(IPFS):
 
-        def __init__(self):
-            super(Swarm.Filters, self).__init__()
+        def __init__(self,**kwargs):
+            super().__init__(**kwargs)
 
         def add(
             self,
@@ -130,8 +130,8 @@ class Swarm(IPFS):
 
     class Peering(IPFS):
 
-        def __init__(self):
-            super(Swarm.Peering, self).__init__()
+        def __init__(self,**kwargs):
+            super().__init__(**kwargs)
 
         def add(
             self,

--- a/ipyfs/ipfs.py
+++ b/ipyfs/ipfs.py
@@ -37,7 +37,7 @@ class IPFS:
 
 
     @staticmethod
-    def _response(response: requests.Response,response_return_status_code=False) -> dict:
+    def _response(response: requests.Response,response_return_status_code=True) -> dict:
         try:
             result = response.json()
         except:

--- a/ipyfs/ipfs.py
+++ b/ipyfs/ipfs.py
@@ -29,6 +29,7 @@ class IPFS:
             from . import RPCs
             if type(init_self_attr_RPCs) is list:
                 rpc_objects=[ obj.capitalize() for obj in init_self_attr_RPCs if obj.capitalize() in dir(RPCs) and type(getattr(RPCs,obj.capitalize())) is type ]
+                rpc_objects+=[ obj.upper() for obj in init_self_attr_RPCs if obj.upper() in dir(RPCs) and type(getattr(RPCs,obj.upper())) is type ]
             else:
               rpc_objects=[ obj for obj in dir(RPCs) if type(getattr(RPCs,obj)) is type ]
             for rpc_object in rpc_objects:

--- a/ipyfs/ipfs.py
+++ b/ipyfs/ipfs.py
@@ -1,5 +1,6 @@
 import sys
 import requests
+import json
 from collections import defaultdict
 
 
@@ -8,7 +9,9 @@ class IPFS:
         self,
         host: str = "http://localhost",
         port: int = 5001,
-        version: int = 0
+        version: int = 0,
+        response_return_status_code: bool = True,
+        init_self_attr_RPCs: bool or list  = False,
     ):
         self.host = host
         self.port = port
@@ -19,29 +22,49 @@ class IPFS:
             f"/{self.__class__.__module__.split('.')[-1].lower()}"
         )
         class_name = self.__class__.__name__.lower()
+        self.response_return_status_code=response_return_status_code
         if class_name not in self.uri:
             self.uri += f"/{class_name}"
+        if self.__class__.__name__=='IPFS' and init_self_attr_RPCs:
+            from . import RPCs
+            if type(init_self_attr_RPCs) is list:
+                rpc_objects=[ obj.capitalize() for obj in init_self_attr_RPCs if obj.capitalize() in dir(RPCs) and type(getattr(RPCs,obj.capitalize())) is type ]
+            else:
+              rpc_objects=[ obj for obj in dir(RPCs) if type(getattr(RPCs,obj)) is type ]
+            for rpc_object in rpc_objects:
+                setattr(self,rpc_object.lower(),getattr(RPCs,rpc_object)(host=host,port=port,version=version,response_return_status_code=response_return_status_code))
+
+
 
     @staticmethod
-    def _response(response: requests.Response) -> dict:
+    def _response(response: requests.Response,response_return_status_code=False) -> dict:
         try:
             result = response.json()
         except:
             result = response.text
             if result == '':
                 result = None
+            else:
+                try:
+                    result=[ json.loads(r) for r in result.splitlines() ]
+                except:
+                    pass
         if response.status_code != 200:
             raise Exception(result)
-        return {
-            "status_code": response.status_code,
-            "result": result
-        }
+        if response_return_status_code:
+            return {
+                "status_code": response.status_code,
+                "result": result
+            }
+        else:
+            return(result)
 
     def _send(
         self,
         params: dict,
         replace: dict = None,
-        file=None
+        file=None,
+        files: dict = None
     ) -> dict:
         """
         Request to IPFS.
@@ -70,6 +93,6 @@ class IPFS:
             requests.post(
                 url=uri,
                 params=data,
-                files={'file': file}
-            )
+                files={'file': file} if files is None else {'file': file , **files}
+            ),self.response_return_status_code
         )


### PR DESCRIPTION
Allows for new usage:
```python
from ipyfs.ipfs import IPFS
ipfs=IPFS(init_self_attr_RPCs=['add','pin','cat','ls'],response_return_status_code=False)
### now we can call ipfs.add instead of making a new Add object
### ... 
### ipfs add -r : 
result=ipfs.add(files={ str(Path(i[0],j)): (str(Path(i[0],j)) , open(Path(i[0],j),'br')) for i in Path(the_path).walk() for j in i[2]})
ls=ipfs.ls(result[-1]['Hash']) ## result is list, last element is the top directory
```

changes: 
 - IPFS:
   - ```__init__```: added arguments
     - response_return_status_code: passed to _response
     - init_self_attr_RPCs : add RPC objects as attributes to the IPFS object ( changed ```__init__``` on multiple classes to allow for that )
   - _response: 
     - argument response_return_status_code: if set to False return just result, since we raise an exception if response.status_code != 200 anyway
     - try to parse result as multiple json lines ( returned as list ), eg. when adding multiple files
   - _send : add argument files dict
- Add : added arguments : 
  - to_files: Add reference to Files API (MFS) 
  - pin_name: Name to use for the pin
  - files: add multiple files
 - Pin: added arguments : 
   - add: 
      - name: An optional name for created pin
   - ls:
     - name: Limit returned pins to ones with names that contain the value provided (case-sensitive, partial match). Implies --names=true. 
     - names: Include pin names in the output 

